### PR TITLE
fix: remove method structure rule, replaced by more granular rules

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -98,6 +98,58 @@ the sample work:
 {{< /tab >}}
 {{< /tabpane >}}
 
+### Main runner
+
+Any declared function arguments should include a no-arg, main method with
+examples for how the user can initialize the method arguments and call the
+entrypoint for the snippet. If the values for these variables need to be
+replaced by the user, be explicit that they are example values only. Wherever
+possible, provide a link to documentation that enumartes the options.
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String filePath = "path/to/image.png";
+    exampleSnippet(projectId, filePath);
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
+### Minimal arguments
+
+Method arguments should be limited to what is absolutely required for testing.
+In most cases, this is project specific information or the path to an external
+file. For example, project specific information (such as `projectId`) or a
+`filePath` for an external file is acceptable, while an argument for the type of
+a file or a specific action is not.
+ 
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+// This is an example snippet for showing best practices.
+public static void exampleSnippet(String projectId, String filePath) {
+    // Snippet content ...
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
+### Process the result
+
+Methods should avoid a return type whenever possible. Instead, show the user how
+to interact with a returned object programmatically by printing some example
+attributes to the console. Tests should use the output of the function to
+ensure that it works.
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+// This is an example snippet for showing best practices.
+public static void exampleSnippet(String projectId, String filePath) {
+    // Snippet content ...
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
 ### Arrange, Act, Assert
 
 Generally, most samples should follow the "Arrange, Act, Assert" pattern as
@@ -163,59 +215,6 @@ Comments should be used as needed, and should follow the following guidelines:
 * Comments should be readable and grammatically correct.
 * For values that the user may wish to configure, provide links to
  documentation that lists available options (and when to use them).
- 
-### Main runner
-
-Any declared function arguments should include a no-arg, main method with
-examples for how the user can initialize the method arguments and call the
-entrypoint for the snippet. If the values for these variables need to be
-replaced by the user, be explicit that they are example values only. Wherever
-possible, provide a link to documentation that enumartes the options.
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-public static void main(String[] args) {
-    // TODO(developer): Replace these variables before running the sample.
-    String projectId = "my-project-id";
-    String filePath = "path/to/image.png";
-    exampleSnippet(projectId, filePath);
-}
-{{< /tab >}}
-{{< /tabpane >}}
-
-### Minimal arguments
-
-Method arguments should be limited to what is absolutely required for testing.
-In most cases, this is project specific information or the path to an external
-file. For example, project specific information (such as `projectId`) or a
-`filePath` for an external file is acceptable, while an argument for the type of
-a file or a specific action is not.
- 
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-// This is an example snippet for showing best practices.
-public static void exampleSnippet(String projectId, String filePath) {
-    // Snippet content ...
-}
-{{< /tab >}}
-{{< /tabpane >}}
-
-### Process the result
-
-Methods should avoid a return type whenever possible. Instead, show the user how
-to interact with a returned object programmatically by printing some example
-attributes to the console. Tests should use the output of the function to
-ensure that it works.
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-// This is an example snippet for showing best practices.
-public static void exampleSnippet(String projectId, String filePath) {
-    // Snippet content ...
-}
-{{< /tab >}}
-{{< /tabpane >}}
-
 
 ### Authentication
  

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -98,38 +98,6 @@ the sample work:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Method Structure
-Method arguments should be limited to what is absolutely required for testing.
-In most cases, this is project specific information or the path to an external
-file. For example, project specific information (such as `projectId`) or a
-`filePath` for an external file is acceptable, while an argument for the type of
-a file or a specific action is not.
- 
-Any declared function arguments should iqnclude a no-arg, main method with
-examples for how the user can initialize the method arguments and call the
-entrypoint for the snippet. If the values for these variables need to be
-replaced by the user, be explicit that they are example values only.
-
-Methods should avoid a return type whenever possible. Instead, show the user how
-to interact with a returned object programmatically by printing some example
-attributes to the console.
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-public static void main(String[] args) {
-    // TODO(developer): Replace these variables before running the sample.
-    String projectId = "my-project-id";
-    String filePath = "path/to/image.png";
-    inspectImageFile(projectId, filePath);
-}
-
-// This is an example snippet for showing best practices.
-public static void exampleSnippet(String projectId, String filePath) {
-    // Snippet content ...
-}
-{{< /tab >}}
-{{< /tabpane >}}
-
 ### Arrange, Act, Assert
 
 Generally, most samples should follow the "Arrange, Act, Assert" pattern as


### PR DESCRIPTION
Removes the Method Structure rule (meant to be removed earlier)
Moves Main runner, Minimal args, and Process the Result from Code section to Structure section.