### PR TITLE
fix: move 'easy run function' section to language specific

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -129,58 +129,6 @@ the sample work:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Main runner
-
-Any declared function arguments should include a no-arg, main method with
-examples for how the user can initialize the method arguments and call the
-entrypoint for the snippet. If the values for these variables need to be
-replaced by the user, be explicit that they are example values only. Wherever
-possible, provide a link to documentation that enumartes the options.
-
-{{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-public static void main(String[] args) {
-    // TODO(developer): Replace these variables before running the sample.
-    String projectId = "my-project-id";
-    String filePath = "path/to/image.png";
-    exampleSnippet(projectId, filePath);
-}
-{{< /tab >}}
-{{< tab header="Node.js" >}}
-function main() {
-  // TODO(developer): Replace these variables before running the sample.
-  const projectId = "my-project-id";
-  const filePath = "path/to/image.png";
-  exampleSnippet(arg1, arg2);
-}
-{{< /tab >}}
-{{< tab header="Ruby">}}
-# [START product_example]
-require "example/resource"
-
-class Example
-  def snippet project_id:, file_path:
-    # Snippet content ...
-  end 
-
-  def self.run
-    # TODO(developer): Replace these variables before running the sample.
-    project_id = "my-project-id"
-    file_path = "path/to/image.png"
-
-    example = Example.new
-    example.snippet project_id: project_id, file_path: file_path
-  end
-end      
-
-if $PROGRAM_NAME == __FILE__   
-  Example.run
-end
-
-# [END product_example]
-{{< /tab >}}
-{{< /tabpane >}}
-
 ### Minimal arguments
 
 Method arguments should be limited to what is absolutely required for testing.
@@ -549,3 +497,62 @@ idiomatic to the language, though cross-language consistency does not hurt.
 Use features that work in all GCP-supported versions of a language and use
 language idioms that the community understands. Generally, do things “the way
 the community does it”.
+
+## Language-specific practices
+
+{{< content-tabpane >}}
+{{< content-tab header="Java" >}}
+
+### Easy run function
+
+Any declared function arguments should include a no-arg, main method with
+examples for how the user can initialize the method arguments and call the
+entrypoint for the snippet. If the values for these variables need to be
+replaced by the user, be explicit that they are example values only. Wherever
+possible, provide a link to documentation that enumartes the options.
+
+
+{{< highlight java >}}
+// [START product_example]
+import com.example.resource;
+
+public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String filePath = "path/to/image.png";
+    exampleSnippet(projectId, filePath);
+}
+
+// This is an example snippet for showing best practices.
+public static void exampleSnippet(String projectId, String filePath) {
+    // Snippet content ...
+}
+// [END product_example]
+{{< / highlight >}}
+
+{{< /content-tab >}}
+
+{{< content-tab header="Python" >}}
+// TODO
+{{< /content-tab >}}
+
+{{< content-tab header="Go" >}}
+// TODO
+{{< /content-tab >}}
+
+{{< content-tab header="Nodejs" >}}
+// TODO
+{{< /content-tab >}}
+
+{{< content-tab header="C#" >}}
+// TODO
+{{< /content-tab >}}
+
+{{< content-tab header="PHP" >}}
+// TODO
+{{< /content-tab >}}
+
+{{< content-tab header="Ruby" >}}
+// TODO
+{{< /content-tab >}}
+{{< /content-tabpane >}}

--- a/layouts/shortcodes/content-tab.html
+++ b/layouts/shortcodes/content-tab.html
@@ -1,0 +1,34 @@
+<!-- 
+     This is a fork from themes/docsy/layouts/shortcodes/tab.html 
+     that allows for using tabs without neccesarily embeding code.
+-->
+
+
+<!-- Make sure that we are enclosed within a tabpane shortcode block -->
+{{ with $.Parent }}
+{{- if ne $.Parent.Name "content-tabpane" -}}
+{{- errorf "content-tab must be used within a content-tabpane block" -}}
+{{- end -}}
+{{- end -}}
+
+<!-- Prefill header if not given as parameter -->
+{{ $header := default (printf "Tab %v" ( add $.Ordinal 1)) (.Get "header") }}
+
+<!-- store all tab info in dict tab -->
+{{ $tab := dict "header" $header }}
+{{ with $.Get "lang" }}
+{{ $tab = merge $tab (dict "language" ($.Get "lang")) }}
+{{ end }}
+{{ with $.Get "highlight" }}
+{{ $tab = merge $tab (dict "highlight" ($.Get "highlight")) }}
+{{ end }}
+{{ with $.Inner }}
+<!-- Trim any leading and trailing newlines from .Inner, this avoids
+     spurious lines during syntax highlighting -->
+{{ $tab = merge $tab (dict "content" (trim $.Inner "\n")) }}
+{{ end }}
+
+<!-- add dict tab to parent's scratchpad -->
+{{ with .Parent }}
+{{- $.Parent.Scratch.SetInMap "tabs" (printf "%v" $.Ordinal) $tab -}}
+{{ end }}

--- a/layouts/shortcodes/content-tabpane.html
+++ b/layouts/shortcodes/content-tabpane.html
@@ -1,0 +1,54 @@
+<!-- 
+     This is a fork from themes/docsy/layouts/shortcodes/tabpane.html 
+     that allows for using tabs without neccesarily embeding code.
+-->
+
+<!-- Scratchpad gets populated through call to .Inner -->  
+{{- .Inner -}}
+
+<ul class="nav nav-tabs" id="tabs-{{- $.Ordinal -}}" role="tablist">
+  {{- range $index, $element := $.Scratch.Get "tabs" -}}
+    <li class="nav-item">
+      <!-- Generate the IDs for the <a> and the <div> elements -->
+      {{- $tabid := printf "tabs-%v-%v-tab" $.Ordinal $index | anchorize -}}
+      {{- $entryid := printf "tabs-%v-%v" $.Ordinal $index | anchorize -}}
+      <!-- Replace space and + from tabname to set class -->
+      {{- $tabname := replaceRE "(\\s)" "-" $element.header -}}
+      {{- $tabname := replaceRE "(\\+)" "-" $tabname -}}
+      <a class="nav-link{{ if eq $index "0" }} active{{ end }} tab-{{ $tabname }}"
+        id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab" onclick="handleClick({{ $tabname }});"
+        aria-controls="{{ $entryid }}" aria-selected="{{- cond (eq $index "0") "true" "false" -}}">
+        {{ index . "header" }}
+      </a>
+    </li>
+  {{- end -}}
+</ul>
+
+<!-- Inner content -->
+<div class="tab-content" id="tabs-{{- $.Ordinal -}}-content">
+  {{- range $index, $element := $.Scratch.Get "tabs" -}}
+
+    {{- $lang := default $.Site.Language.Lang ($.Get "lang") -}}
+    {{with $.Get "langEqualsHeader"}}
+        {{ if $.Get "langEqualsHeader"}}
+          {{ $lang = $element.header }}
+        {{end}}
+    {{end}}
+    {{- $hloptions := default "" ($.Get "highlight") -}}
+    {{- with $element.language -}}
+      {{  $lang = $element.language }}
+    {{- end -}}
+    {{- with $element.highlight -}}
+      {{  $hloptions = $element.highlight }}
+    {{- end -}}
+    {{- $tabid := printf "tabs-%v-%v-tab" $.Ordinal $index | anchorize -}}
+    {{- $entryid := printf "tabs-%v-%v" $.Ordinal $index | anchorize -}}
+    <div class="tab-pane fade{{ if eq $index "0" }} show active{{ end }}"
+        id="{{ $entryid }}" role="tabpanel" aria-labelled-by="{{ $tabid }}"
+        style="border: 1px solid rgba(0, 0, 0, 0.125)">
+      <div style="padding: 1rem" >
+        {{ index . "content" | markdownify }}
+      </div>
+    </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
Move the "easy run function" into a java specific section until there is a consensus on whether this pattern is useful for other languages. 

This PR also establishes the language-specific section:

![image](https://user-images.githubusercontent.com/31518063/160303376-42b3d4a5-2ef7-4e30-acec-aec8ac530cbb.png)

