### PR TITLE
feat: add PHP guide samples

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -234,7 +234,6 @@ public static void listInfoTypes() throws IOException {
 }
 {{< /tab >}}
 {{< tab header="PHP" >}}
-<?php
 /**
  * Lists all Info Types for the Data Loss Prevention (DLP) API.
  */

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -242,7 +242,11 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
  * @param string $filter        (Optional) filter to use
  * @param string $languageCode  (Optional) language code, empty for 'en-US'
  */
-function list_info_types(string $filter = '', string $languageCode = ''): void
+function list_info_types(
+    // TODO(developer): Replace these values before running your sample: 
+    string $filter = 'your-filter', 
+    string $languageCode = 'your-language-code'): void
+{
     // Arrange: Instantiate a client.
     $dlp = new DlpServiceClient();
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -537,23 +537,22 @@ use Google\Cloud\Dlp\V2\DlpServiceClient;
 
 /**
  * Lists all Info Types for the Data Loss Prevention (DLP) API.
- *
- * @param string $filter        (Optional) filter to use
- * @param string $languageCode  (Optional) language code, empty for 'en-US'
  */
-function list_info_types(
-    // TODO(developer): Replace these values before running your sample: 
-    string $filter = 'your-filter', 
-    string $languageCode = 'your-language-code'): void
+function list_info_types(): void
 {
     // Arrange: Instantiate a client.
     $dlp = new DlpServiceClient();
 
     // Arrange: Prepare the request parameters.
     $params = [
-        'languageCode' => $languageCode,
-        'filter' => $filter
-    ]
+        // Only return infoTypes supported by certain parts of the API.
+        // Supported filters: "supported_by=INSPECT" and "supported_by=RISK_ANALYSIS"
+        'filter' =>'supported_by=INSPECT',
+
+        // BCP-47 language code for localized infoType friendly names.
+        // Defaults to "en_US"
+        'languageCode' => 'en-US'
+    ];
 
     // Act: Run the request.
     $response = $dlp->listInfoTypes($params);

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -80,6 +80,15 @@ def example_snippet():
 
 # [END product_example]
 {{< /tab >}}
+{{< tab header="PHP" >}}
+// [START product_example]
+use Example\Resource
+
+function example_snippet() {
+    // Snippet Content ...
+}
+// [END product_example]
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### Sample description
@@ -95,6 +104,14 @@ the sample work:
 *
 * See https://cloud.google.com/compute/docs/quickstart-client-libraries before running the code snippet.
 */
+{{< /tab >}}
+{{< tab header="PHP" >}}
+/**
+ * Moves a persistent disk from one zone to another.
+ *
+ * See https://cloud.google.com/compute/docs/quickstart-client-libraries
+ * before running the code snippet.
+ */
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -132,6 +149,12 @@ public static void exampleSnippet(String projectId, String filePath) {
     // Snippet content ...
 }
 {{< /tab >}}
+{{< tab header="PHP" >}}
+// This is an example snippet for showing best practices.
+function example_snippet(string $projectId, string $filePath) {
+    // Snippet content ...
+}
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### Process the result
@@ -146,6 +169,17 @@ ensure that it works.
 // This is an example snippet for showing best practices.
 public static void exampleSnippet(String projectId, String filePath) {
     // Snippet content ...
+}
+{{< /tab >}}
+{{< tab header="PHP" >}}
+// This is an example snippet for showing best practices.
+function example_snippet(string $projectId, string $filePath) {
+    // Snippet content ...
+    printf(
+      'Response values: %s, %s',
+      $response->getExampleName(),
+      $response->getExampleValue()
+    );
 }
 {{< /tab >}}
 {{< /tabpane >}}
@@ -197,6 +231,38 @@ public static void listInfoTypes() throws IOException {
   }
 }
 {{< /tab >}}
+{{< tab header="PHP" >}}
+/**
+ * Lists all Info Types for the Data Loss Prevention (DLP) API.
+ */
+use Google\Cloud\Dlp\V2\DlpServiceClient;
+
+/** Uncomment and populate these variables in your code */
+// $filter = ''; // (Optional) filter to use, empty for ''.
+// $languageCode = ''; // (Optional) language code, empty for 'en-US'.
+
+// Arrange: Instantiate a client.
+$dlp = new DlpServiceClient();
+
+// Arrange: Prepare request parameters.
+$params = [
+    'languageCode' => $languageCode,
+    'filter' => $filter,
+]
+
+// Act: Run the request.
+$response = $dlp->listInfoTypes($params);
+
+// Assert: Print the results.
+print('Info Types:' . PHP_EOL);
+foreach ($response->getInfoTypes() as $infoType) {
+    printf(
+        '  %s (%s)' . PHP_EOL,
+        $infoType->getDisplayName(),
+        $infoType->getName()
+    );
+}
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### No CLIs
@@ -222,16 +288,25 @@ Samples should use authenticate using [Application Default Credentials][ADC].
  
 If the code snippet is platform specific, explicitly show how to use that
 platform's credentials.
- 
+
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="Java" >}}
 // Most clients use ADC by default. However, if your application needs to showcase a specific
 // credential source, show users how to do that explicitly.
 GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream("/path/to/credentials.json"));
 {{< /tab >}}
+{{< tab header="PHP" >}}
+// Most clients use ADC by default. However, if your application needs to showcase a specific
+// credential source, show users how to do that explicitly.
+$config = [
+    'keyFilePath' => '/path/to/credentials.json',
+    'projectId' => $projectId,
+];
+$storage = new StorageClient($config);
+{{< /tab >}}
 {{< /tabpane >}}
  
-[ADC]: (https://cloud.google.com/docs/authentication/production)
+[ADC]: https://cloud.google.com/docs/authentication/production
 
 ### Initializing Clients
  
@@ -250,6 +325,12 @@ try (CloudClient dlp = CloudClient.create()) {
   // make a request with the client
 }
 {{< /tab >}}
+{{< tab header="PHP" >}}
+// Initialize client that will be used to send requests.
+// This client only needs to be created once, reuse it for multiple requests.
+
+$dlp = new DlpServiceClient();
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### Cyclomatic Complexity
@@ -265,7 +346,7 @@ extra code.
 ### Error Handling
 
 Samples should include examples and details of how to catch and handle common
-errors that are the result of improper interactions with the client or service. 
+errors that are the result of improper interactions between the client and service.
 
 If there is no solution (or if the solution is too verbose to resolve in a
 sample) it is acceptable to either log or leave a comment explaining what the
@@ -278,6 +359,14 @@ try {
   // Do something
 } catch (IllegalArgumentException ok) {
   // IllegalArgumentException's are thrown when an invalid argument has been passed to a function. Ok to ignore.
+}
+{{< /tab >}}
+{{< tab header="PHP" >}}
+// Catch the most specific type of Exception, instead of a more general one.
+try {
+    // Do something.
+} catch (InvalidArgumentException $e) {
+    // IllegalArgumentException is thrown when an invalid argument has been passed to a function.
 }
 {{< /tab >}}
 {{< /tabpane >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -151,7 +151,8 @@ public static void exampleSnippet(String projectId, String filePath) {
 {{< /tab >}}
 {{< tab header="PHP" >}}
 // This is an example snippet for showing best practices.
-function example_snippet(string $projectId, string $filePath) {
+function example_snippet(string $projectId, string $filePath): void
+{
     // Snippet content ...
 }
 {{< /tab >}}
@@ -173,7 +174,8 @@ public static void exampleSnippet(String projectId, String filePath) {
 {{< /tab >}}
 {{< tab header="PHP" >}}
 // This is an example snippet for showing best practices.
-function example_snippet(string $projectId, string $filePath) {
+function example_snippet(string $projectId, string $filePath): void
+{
     // Snippet content ...
     printf(
       'Response values: %s, %s',

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -178,9 +178,9 @@ function example_snippet(string $projectId, string $filePath): void
 {
     // Snippet content ...
     printf(
-      'Response values: %s, %s',
-      $response->getExampleName(),
-      $response->getExampleValue()
+        'Response values: %s, %s',
+        $response->getExampleName(),
+        $response->getExampleValue()
     );
 }
 {{< /tab >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -939,7 +939,44 @@ public static void exampleSnippet(String projectId, String filePath) {
 {{< /content-tab >}}
 
 {{< content-tab header="PHP" >}}
-// TODO
+
+### Easy run function
+
+Samples with function parameters should show how to prepare parameter values
+and call the function. Do this from a `callSample()` function below the main
+sample code. Do not include significant logic in the `callSample()` function,
+and do not write tests for it.
+
+Direct the developer to change the parameter values from the provided examples.
+
+Where possible, provide a link to documentation that explains the options.
+
+{{<highlight PHP>}}
+// [START product_example]
+
+/**
+ * Example snippet showing the easy run function rule.
+ *
+ * @param string $projectId         Google Cloud Project
+ * @param string $filePath          Path to file for processing
+ */
+function example_snippet(string $projectId, string $filePath): void
+{
+    // Snippet content ...
+}
+
+/**
+ * TODO(developer): Replace sample parameters before running the code.
+ */
+function callSample(): void
+{
+    $projectId = 'your-project-id';
+    $filePath = 'path/to/image.png';
+    example_snippet($projectId, $region);
+}
+// [END product_example]
+{{< / highlight >}}
+
 {{< /content-tab >}}
 
 {{< content-tab header="Ruby" >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -234,35 +234,40 @@ public static void listInfoTypes() throws IOException {
 }
 {{< /tab >}}
 {{< tab header="PHP" >}}
+<?php
 /**
  * Lists all Info Types for the Data Loss Prevention (DLP) API.
  */
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 
-/** Uncomment and populate these variables in your code */
-// $filter = ''; // (Optional) filter to use, empty for ''.
-// $languageCode = ''; // (Optional) language code, empty for 'en-US'.
+/**
+ * Lists all Info Types for the Data Loss Prevention (DLP) API.
+ *
+ * @param string $filter        (Optional) filter to use
+ * @param string $languageCode  (Optional) language code, empty for 'en-US'
+ */
+function list_info_types(string $filter = '', string $languageCode = ''): void
+    // Arrange: Instantiate a client.
+    $dlp = new DlpServiceClient();
 
-// Arrange: Instantiate a client.
-$dlp = new DlpServiceClient();
+    // Arrange: Prepare the request parameters.
+    $params = [
+        'languageCode' => $languageCode,
+        'filter' => $filter
+    ]
 
-// Arrange: Prepare request parameters.
-$params = [
-    'languageCode' => $languageCode,
-    'filter' => $filter,
-]
+    // Act: Run the request.
+    $response = $dlp->listInfoTypes($params);
 
-// Act: Run the request.
-$response = $dlp->listInfoTypes($params);
-
-// Assert: Print the results.
-print('Info Types:' . PHP_EOL);
-foreach ($response->getInfoTypes() as $infoType) {
-    printf(
-        '  %s (%s)' . PHP_EOL,
-        $infoType->getDisplayName(),
-        $infoType->getName()
-    );
+    // Assert: Print the results.
+    print('Info Types:' . PHP_EOL);
+    foreach ($response->getInfoTypes() as $infoType) {
+        printf(
+            '  %s (%s)' . PHP_EOL,
+            $infoType->getDisplayName(),
+            $infoType->getName()
+        );
+    }
 }
 {{< /tab >}}
 {{< /tabpane >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -234,9 +234,6 @@ public static void listInfoTypes() throws IOException {
 }
 {{< /tab >}}
 {{< tab header="PHP" >}}
-/**
- * Lists all Info Types for the Data Loss Prevention (DLP) API.
- */
 use Google\Cloud\Dlp\V2\DlpServiceClient;
 
 /**


### PR DESCRIPTION
This PR creates PHP samples to illustrate sample guidelines. Where these guidelines imply a change to current practice, the idea is this would be the new practice going forward. For example, scalar type hints in function parameters.

This PR excludes a "main runner" example, PHP is moving towards using something like that (an `executeSample()` helper function), but we'll tackle how to present that in the future.