### PR TITLE
chore: skip PR preview/cleanup on forks

### DIFF
--- a/.github/workflows/github_pages_preview.yml
+++ b/.github/workflows/github_pages_preview.yml
@@ -64,6 +64,9 @@ jobs:
       - run: hugo --minify
 
       - name: Deploy
+        # If run from a fork, GitHub write operations will fail.
+        # See https://github.com/GoogleCloudPlatform/samples-style-guide/issues/56
+        if: github.repository == 'googlecloudplatform/samples-style-guide'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +75,9 @@ jobs:
           commit_message: "stage: PR-${{ github.event.number }}: ${{ github.event.head_commit.message }}"
 
       - name: Comment
+        # If run from a fork, GitHub write operations will fail.
+        # See https://github.com/GoogleCloudPlatform/samples-style-guide/issues/56
+        if: github.repository == 'googlecloudplatform/samples-style-guide'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/github_pages_preview_clean.yml
+++ b/.github/workflows/github_pages_preview_clean.yml
@@ -23,6 +23,9 @@ on:
 
 jobs:
   clean:
+    # If run from a fork, GitHub write operations will fail.
+    # See https://github.com/GoogleCloudPlatform/samples-style-guide/issues/56
+    if: github.repository == 'googlecloudplatform/samples-style-guide'
     runs-on: ubuntu-20.04
     concurrency:
       # Shared concurrency group wih preview staging.


### PR DESCRIPTION
Temporary solution for #56, this should skip running the write operations (github push, comment) when a workflow is triggered from a fork. This will still run the build.

#56 starts exploring some maybe better solutions to keep previews working for forks, but we need more discussion of preferred workflow and security stance in those situations.