### PR TITLE
fix(testing): disable write ops from forking pull requests (retry)

### DIFF
--- a/.github/workflows/github_pages_preview.yml
+++ b/.github/workflows/github_pages_preview.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Deploy
         # If run from a fork, GitHub write operations will fail.
         # See https://github.com/GoogleCloudPlatform/samples-style-guide/issues/56
-        if: github.repository == 'googlecloudplatform/samples-style-guide'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
       - name: Comment
         # If run from a fork, GitHub write operations will fail.
         # See https://github.com/GoogleCloudPlatform/samples-style-guide/issues/56
-        if: github.repository == 'googlecloudplatform/samples-style-guide'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/github_pages_preview_clean.yml
+++ b/.github/workflows/github_pages_preview_clean.yml
@@ -25,7 +25,7 @@ jobs:
   clean:
     # If run from a fork, GitHub write operations will fail.
     # See https://github.com/GoogleCloudPlatform/samples-style-guide/issues/56
-    if: github.repository == 'googlecloudplatform/samples-style-guide'
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-20.04
     concurrency:
       # Shared concurrency group wih preview staging.


### PR DESCRIPTION
Fixes #56 
I updated the issue with more detailed research notes, but tl;dr: my previous research on fixing this problem didn't work out, so I found a more targeted way to identify if a Pull Request is coming from a fork.