### PR TITLE
Added Terraform to existing style guide

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1262,6 +1262,7 @@ those products in Terraform samples.
 
 Don't include global Terraform variables (`var.VARIABLE_NAME`).
 
+{{% alert title="Explanation" %}}
 Global variables become part of the API exposed via Terraform.
 Therefore, global variables help enable users to use Terraform samples
 not as snippets but as direct module references. 
@@ -1272,7 +1273,10 @@ accidentally dependent on our samples.
 Instead of including global variables, hard code the resource names and
 parameter values.
 
-In some cases, [local variables](#locals) are allowed.
+Local variables are allowed in Terraform samples
+because local variables are an internal implementation and therefore aren't
+part of the API exposed via Terraform. See [local variables](#locals).
+{{% /alert %}}
 
 #### Local variables {#locals}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1242,45 +1242,4 @@ the provider documentation.
 
 {{< /content-tabpane >}}
 
-### Testing practices
-
-{{< content-tabpane >}}
-{{< content-tab header="Ruby" >}}
-Each Ruby sample should have its own separate test file. Sample tests should
-use the [Minitest][minitest] framework, and should be located in a file named
-`<sample-name>_test.rb` under the `acceptance` directory.
-
-Be aware that sample methods are defined at the top level and would thus be
-added to the `Object` class if the file is loaded directly. In most cases,
-tests should define a temporary class and load the sample in that class. Ruby
-repositories may provide tools to help with this process, but it can also be
-done with `eval`.
-
-Example test: `acceptance/read_a_file.rb`:
-
-{{< highlight ruby >}}
-require "minitest/autorun"
-require "tmpdir"
-
-# Load the sample into this class so the method isn't defined on Object.
-class ReadAFileSample
-  sample_file = File.read "#{__dir__}/../read_a_file.rb"
-  eval sample_file
-end
-
-describe "#read_a_file" do
-  # Test the critical code paths
-  it "reads a file" do
-    Dir.mktmpdir do |dir|
-      File.write "#{dir}/my-test.txt", "Hello, Ruby!"
-      assert_output "Contents: Hello, Ruby!\n" do
-        ReadAFileSample.new.read_a_file file_path: "#{dir}/my-test.txt"
-      end
-    end
-  end
-end
-{{< /highlight >}}
-
-[minitest]: https://github.com/minitest/minitest
-
 {{< /content-tabpane >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -287,20 +287,23 @@ end
 function example_snippet(string $projectId, string $filePath): void
 {{< /tab >}}
 {{< tab header="Terraform" >}}
-#  These are example snippets for showing best practices.
-#
-# Don't include the 'project' argument in resources. Rely on
-# the 'GOOGLE_CLOUD_PROJECT' environment variable as documented at
-# https://cloud.google.com/docs/terraform/basic-commands.
-#
-# Some resources, such as 'project_iam_*', cannot infer the project ID.
-# As a workaround, use the 'data "google_project"' data source.
-
-#
-# Some resources, such as `project_iam_*`, cannot infer the project ID.
-# As a workaround, use the `data "google_project"` data source.
-#
-# Creates an IAM policy
+/*  These are example snippets for showing best practices.
+*
+* Don't include the 'project' argument in resources. Rely on
+* the 'GOOGLE_CLOUD_PROJECT' environment variable as documented at
+* https://cloud.google.com/docs/terraform/basic-commands.
+*
+* Some resources, such as 'project_iam_*', cannot infer the project ID.
+* As a workaround, use the 'data "google_project"' data source.
+*
+*
+* Some resources, such as `project_iam_*`, cannot infer the project ID.
+* As a workaround, use the `data "google_project"` data source.
+* In the following configuration, the `google_project.project` data source
+* automatically looks up the project ID of the local project.
+*
+* Creates an IAM policy
+*/
 
 data "google_project" "project" {
 }

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -662,35 +662,23 @@ function list_info_types(): void
 
 // Arrange: Set local values.
 locals {
-  domain = "example.me"
-  name   = "prefixname"
+  name   = "example-namespace"
 }
 
 // Arrange: Create random value to help ensure unique resource names.
-resource "random_id" "tf_prefix" {
+resource "random_id" "suffix" {
   byte_length = 4
 }
 
 // Act: Create the resources.
-resource "google_project_service" "certificatemanager_svc" {
-  service            = "certificatemanager.googleapis.com"
-  disable_on_destroy = false
-}
-
-resource "google_dns_managed_zone" "default" {
-  name        = "example-mz-${random_id.tf_prefix.hex}"
-  dns_name    = "${local.domain}."
-  description = "Example DNS zone"
-
-  # More resource arguments ...
+resource "google_project" "example_project" {
+  name = "${local.name}"
+  project_id = "${local.name}-{random_id.suffix.hex}"
 }
 
 // Assert: Print the results.
-output "domain_name_servers" {
-  value = google_dns_managed_zone.default.name_servers
-}
-output "certificate_map" {
-  value = google_certificate_manager_certificate_map.certificate_map.id
+output "project_id" {
+  value = google_project.example_project.id
 }
 {{< /tab >}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -659,8 +659,6 @@ function list_info_types(): void
 {{< /tab >}}
 
 {{< tab header="Terraform" >}}
-# Define any local variables at the beginning of the sample.
-# Include any output statements at the end of the sample.
 
 // Arrange: Set local values.
 locals {

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -144,8 +144,7 @@ function example_snippet() {
 {{< /tab >}}
 
 {{< tab header="Terraform" >}}
-N/A
-// [END product_example]
+# N/A
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -310,14 +310,10 @@ data "google_project" "project" {
 
 data "google_iam_policy" "sql_iam_policy" {
   binding {
-    role = "roles/cloudsql.client"
-    members = [
-      "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
-    ]
+    ...
     condition {
-      expression  = "resource.name == 'projects/${data.google_project.project.id}/instances/${google_sql_database_instance.default.name}' && resource.type == 'sqladmin.googleapis.com/Instance'"
-      title       = "created"
-      description = "Cloud SQL instance creation"
+      expression  = "resource.name == 'projects/${data.google_project.project.id}/instances/${google_sql_database_instance.default.name}'"
+      ...
     }
   }
 }

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -33,7 +33,8 @@ descending order of priority:
 
 1. **Clarity**: The code's purpose and rationale is clear to the reader
 2. **Idiomaticity**: The code should be written using idiomatic,
-   community-driven coding practices
+   community-driven coding practices, except where these practices
+   negatively impact clarity, simplicity, or maintainability
 3. **Consistency**: The code has the same implementation from language to
    language
 4. **Simplicity**: The code accomplishes its goal in the simplest way possible

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1285,11 +1285,11 @@ accessible as a resource reference.
 
 #### Resource references
 
-When possible, refer to already-defined resources.
+Instead of duplicating know values, refer to already-defined resources.
 
-For example,
-the `target` argument is referring to a `google_compute_target_ssl_proxy`
-resource called `default` to get the `id` attribute of that resource.
+For example, the `target` argument is referring to a
+`google_compute_target_ssl_proxy` resource called `default` to get the
+`id` attribute of that resource.
 
 {{< highlight terraform >}}
 resource "google_compute_global_forwarding_rule" "default" { 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -912,7 +912,7 @@ spanner_client.close
 $dlp = new DlpServiceClient();
 {{< /tab >}}
 {{< tab header="Terraform" >}}
-N/A
+# N/A
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1248,12 +1248,10 @@ part of the API exposed via Terraform. See [local variables](#locals).
 
 #### Local variables {#locals}
 
-Unlike global veriables, local variables are allowed in Terraform samples
-because local variables are an internal implementation and therefore aren't
-part of the API exposed via Terraform.
-
 Use local variables to reuse a common string 3 or more times that is not
 accessible as a resource reference.
+
+See [No Global Variables](#no-global-variables) for further explanation.
 
 #### Resource references
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -684,13 +684,13 @@ output "project_id" {
 
 {{< /tabpane >}}
 
-### No use of external tools {#no-external-tools}
+### No CLIs {#no-cli}
 
-Do not include external tools such as CLIs in your sample. We expect
-developers to copy and paste code directly from cloud.google.com into their
+Do not include CLIs for running your sample. We expect developers
+to copy and paste code directly from cloud.google.com into their
 own environment.
 
-Previous practice shows external tools are expensive to maintain and detract
+Previous practice shows CLIs are expensive to maintain and detracts
 from the purpose of the snippet.
 
 ## Code {#code}
@@ -1226,7 +1226,7 @@ end
 {{< /content-tab >}}
 
 {{< content-tab header="Terraform" >}}
-#### No CLIs
+#### Don't use `null_resource`
 
 Do not include CLI commands (such as gcloud or kubectl) inside
 of your sample via the `null_resource` resource.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -396,9 +396,7 @@ function example_snippet(string $projectId, string $filePath): void
 {{< /tab >}}
 {{< tab header="Terraform" >}}
 # Output statement provide values that are generated after creating
-# a resource. They are allowed because they are readonly and they
-# give users some important information such as URLs and IP addresses.
-# To keep it simple, they must be defined inline at the end of
+# a resource. To keep it simple, they must be defined inline at the end of
 # a  sample, not in a separate `outputs.tf` file.
 
 output "domain_name_servers" {

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1224,7 +1224,7 @@ Add the provider argument if the resource is from provider google-beta.
 resource "google_<resource_name>" "default" {
   provider = google-beta
 
-  # Other esource arguments ...
+  # Other resource arguments ...
 }
 
 Fields and resources that are only present in google-beta are clearly marked in

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1233,5 +1233,3 @@ the provider documentation.
 {{< /content-tab >}}
 
 {{< /content-tabpane >}}
-
-{{< /content-tabpane >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1276,8 +1276,12 @@ Fields and resources that are only present in google-beta are clearly marked in
 the provider documentation.
 {{< /content-tab >}}
 
+{{< /content-tabpane >}}
+
 ### Testing practices
 
+{{< content-tabpane >}}
+{{< content-tab header="Ruby" >}}
 Each Ruby sample should have its own separate test file. Sample tests should
 use the [Minitest][minitest] framework, and should be located in a file named
 `<sample-name>_test.rb` under the `acceptance` directory.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1277,7 +1277,9 @@ accessible as a resource reference.
 
 #### Resource references
 
-When possible, refer to already-defined resources. For example,
+When possible, refer to already-defined resources.
+
+For example,
 the `target` argument is referring to a `google_compute_target_ssl_proxy`
 resource called `default` to get the `id` attribute of that resource.
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1215,9 +1215,8 @@ terraform {
 
 To determine when a resource was added, see the following pages:
    
-# https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md
-   
-# https://github.com/hashicorp/terraform-provider-google-beta/blob/main/CHANGELOG.md
+* https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md
+* https://github.com/hashicorp/terraform-provider-google-beta/blob/main/CHANGELOG.md
 
 #### Provider argument
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -10,14 +10,14 @@ weight: 20
 This document defines samples standards for "standalone" code snippets.
 It encourages recommended practices for authoring code intended to teach others.
 By consistently applying these practices, the collection of samples as a whole
-become more approachable.
+becomes more approachable.
 
-Even if not specifically mentioned in the guide, all samples should make
-best-efforts to achieve the following goals wherever possible:
+All samples should make best-efforts to achieve the following goals wherever
+possible:
 
 * **Copy-paste-runnable** - Users should be able to copy, paste, and run the
-code into their environment with as few changes as possible. Samples should be
-easy as possible for a user to run.
+code in their environment with as few changes as possible. Samples should be
+as easy as possible for a user to run.
 
 * **Teach through code** - Samples should teach users both how and _why_
 specific best practices should be implemented and performed when interacting
@@ -28,14 +28,13 @@ to language, framework, or service.
 
 ### Principles {#principles}
 
-Where the guidelines below are insufficient, these principles apply in
-descending order of priority:
+These principles apply in descending order of priority:
 
 1. **Clarity**: The code's purpose and rationale is clear to the reader
 2. **Idiomaticity**: The code should be written using idiomatic,
    community-driven coding practices
-3. **Consistency**: The code has the same implementation from language to
-   language
+3. **Consistency**: The code has the same implementation from
+   language-to-language
 4. **Simplicity**: The code accomplishes its goal in the simplest way possible
 5. **Portability**: The code should be able to run locally or in the Cloud
 6. **Maintainability**: The code is written such that it can be easily
@@ -53,21 +52,21 @@ though cross-language consistency does not hurt. Generally, do things
 ### Region tags {#region-tags}
 
 Each code snippet should have a region tag to define which parts of the snippet
-are displayed from the documentation. Each region tag should be:
+are displayed from the documentation. Each region tag should:
 
-* Globally unique
-* Consistent across the same snippets in different languages
-* Begins with the product's region tag prefix
-* In snake case (`snake_case`)
+* Be globally unique
+* Be consistent across the same snippets in different languages
+* Begin with the product's region tag prefix
+* Use snake case (`snake_case`)
 
 Region tags should show as much of the sample as possible, so that a user can
 easily copy and paste the sample into their own environment to run it.
 
 ### Imports {#imports}
 
-Samples should include any imports statements the code depends on.
+Samples should include any import statements that the code depends on.
 
-This is easiest to enforce/detect when the samples are in their own file, see
+This is easiest to enforce/detect when the samples are in their own file. See
 the [one sample per file](#one-per-file) guideline.
 
 {{< tabpane langEqualsHeader=true >}}
@@ -1221,11 +1220,14 @@ To determine when a resource was added, see the following pages:
 #### Provider argument
 
 Add the provider argument if the resource is from provider google-beta.
+   
+{{< highlight terraform >}}
 resource "google_<resource_name>" "default" {
   provider = google-beta
 
   # Other resource arguments ...
 }
+{{< /highlight >}}
 
 Fields and resources that are only present in google-beta are clearly marked in
 the provider documentation.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -983,15 +983,6 @@ Examples of portable practices include:
 
 ## Testing {#testing}
 
-### Test infrastructure
-
-We recommend using a test infrastructure that spins up a clean project
-for each test.
-
-Testing infrastructure code means that you are deploying actual resources.
-To avoid incurring charges, consider implementing a clean-up step.
-Some testing frameworks have a built-in cleanup step for you.
-
 ### Coverage {#coverage}
 
 Code snippets should have reasonable test coverage and all critical code paths

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1155,9 +1155,7 @@ end
 #### Don't use `null_resource`
 
 Do not include CLI commands (such as gcloud or kubectl) inside
-of your sample via the `null_resource` resource.
-
-# https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource
+of your sample via the [`null_resource`](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) resource.
 
 There are some products without Terraform support. Do not include
 those products in Terraform samples.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -289,19 +289,12 @@ function example_snippet(string $projectId, string $filePath): void
 {{< tab header="Terraform" >}}
 #  These are example snippets for showing best practices.
 #
-# Don't include the `project` argument in resources.
-# The guidance at https://cloud.google.com/docs/terraform/basic-commands
-# shows how to use an `export` statement to set the Google Cloud project
-# where you want to apply the Terraform configuration.
+# Don't include the 'project' argument in resources. Rely on
+# the 'GOOGLE_CLOUD_PROJECT' environment variable as documented at
+# https://cloud.google.com/docs/terraform/basic-commands.
 #
-# If you run the `export GOOGLE_CLOUD_PROJECT` command, most resources
-# can infer the project ID.
-
-#  Creates a VPC network
-resource "google_compute_network" "default" {
-  name                    = "my-network"
-  auto_create_subnetworks = false
-}
+# Some resources, such as 'project_iam_*', cannot infer the project ID.
+# As a workaround, use the 'data "google_project"' data source.
 
 #
 # Some resources, such as `project_iam_*`, cannot infer the project ID.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -212,11 +212,13 @@ See https://cloud.google.com/compute/docs/quickstart-client-libraries before run
  */
 {{< /tab >}}
 {{< tab header="Terraform" >}}
-# Create a VM instance from a public image
-# in the `default` VPC network and subnet
+/* 
+Create a VM instance from a public image
+in the `default` VPC network and subnet
 
-# See https://cloud.google.com/compute/docs/instances/create-start-instance
-# before running the code snippet.
+See https://cloud.google.com/compute/docs/instances/create-start-instance
+before running the code snippet.
+*/
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1224,8 +1224,11 @@ terraform {
 }
 {{< /highlight >}}
 
-To determine when a resource was added, see the terraform-provider-google/CHANGELOG.md or 
-terraform-provider-google-beta/CHANGELOG.md.
+To determine when a resource was added, see the following pages:
+   
+# https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md
+   
+# https://github.com/hashicorp/terraform-provider-google-beta/blob/main/CHANGELOG.md
 
 #### Provider argument
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1005,11 +1005,13 @@ try {
 }
 {{< /tab >}}
 {{< tab header="Terraform" >}}
-Rely on Terraform's default logging, both for our maintenance and for developer
-practice.
+/**
+ * Rely on Terraform's default logging, both for our maintenance and for developer
+ * practice.
 
-Do not use [`try` statements](https://developer.hashicorp.com/terraform/language/functions/try)
-in Terraform samples.
+ * Do not use [`try` statements](https://developer.hashicorp.com/terraform/language/functions/try)
+ * in Terraform samples.
+*/
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -672,7 +672,6 @@ resource "random_id" "tf_prefix" {
 }
 
 // Act: Create the resources.
-# [START certificatemanager_dns_wildcard]
 resource "google_project_service" "certificatemanager_svc" {
   service            = "certificatemanager.googleapis.com"
   disable_on_destroy = false
@@ -685,10 +684,6 @@ resource "google_dns_managed_zone" "default" {
 
   # More resource arguments ...
 }
-
-# More resources ...
-
-# [END certificatemanager_dns_wildcard]
 
 // Assert: Print the results.
 output "domain_name_servers" {

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1320,4 +1320,8 @@ end
 [minitest]: https://github.com/minitest/minitest
 
 {{< /content-tab >}}
+{{< content-tab header="Terraform" >}}
+For information about testing, see the Terraform samples [contributing guide]
+(https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md).
+{{< /content-tab >}}
 {{< /content-tabpane >}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1281,13 +1281,13 @@ When possible, refer to already-defined resources. For example,
 the `target` argument is referring to a `google_compute_target_ssl_proxy`
 resource called `default` to get the `id` attribute of that resource.
 
-```
+{{< highlight terraform >}}
 resource "google_compute_global_forwarding_rule" "default" { 
   target = google_compute_target_ssl_proxy.default.id # Reference to already defined resource in the sample
 
-  # Other esource arguments ...
+  # Other resource arguments ...
 }
-```
+{{< /highlight >}}
 
 #### Terraform Google Provider version
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1297,6 +1297,7 @@ provider version introduced a resource. For example, `google_apigee_nat_address`
 was added in version 4.37, so the minimum version is 4.37. To specify a minimum
 version in a sample, include the provider requirements, as follows:
 
+{{< highlight terraform >}}
 terraform {
   required_providers {
     google = {
@@ -1305,6 +1306,7 @@ terraform {
     }
   }
 }
+{{< /highlight >}}
 
 To determine when a resource was added, see the terraform-provider-google/CHANGELOG.md or 
 terraform-provider-google-beta/CHANGELOG.md.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -960,7 +960,7 @@ operating systems.
 
 Our code snippets may be executed in multiple hosting environments, such as
 [App Engine][gae], [Cloud Functions][gcf], [Cloud Run][run],
-[Kubernetes Engine][gke], [Compute Engine][gce], [Cloud Shell][shell],
+[Kubernetes Engine][gke], [Compute Engine][gce], Cloud Shell,
 other cloud providers, and local machines.
 
 Where possible, code snippets should work across environments and hosting
@@ -982,26 +982,6 @@ Examples of portable practices include:
 [shell]: https://cloud.google.com/shell
 
 ## Testing {#testing}
-
-### Cloud Shell
-
-When possible, perform testing in Cloud Shell. Cloud Shell runs in a Compute
-Engine virtual machine. The service credentials associated with this virtual
-machine are automatic, so there is no need to set up or download a service
-account key.
-
-Cloud Shell provides you with command-line access to your cloud resources
-directly from your browser.
-
-[ide.cloud.google.com](ide.cloud.google.com) extends Cloud Shell with an
-online development environment that includes:
-
-* Cloud-native development via Cloud Code plugin support
-
-* Rich language support for Go, Java, .Net, Python and NodeJS 
-
-* Additional features such as integrated source control and support for
-  multiple projects
 
 ### Test infrastructure
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1247,17 +1247,27 @@ of your sample via the `null_resource` resource.
 There are some products without Terraform support. Do not include
 those products in Terraform samples.
 
-#### No Variables
+#### No global variables
 
-Don't include Terraform variables (`var.VARIABLE_NAME`). Variables
-enabling users to use Terraform samples not as snippets but as direct
-module references. Disabling the avenue of customization 
-reduces the risk so that users don't take accidental 
-dependency.
-Instead, hard code the resource names and attribute values.
-In some cases, [locals](#locals) are allowed.
+Don't include global Terraform variables (`var.VARIABLE_NAME`).
 
-#### Locals {#locals}
+Global variables become part of the API exposed via Terraform.
+Therefore, global variables help enable users to use Terraform samples
+not as snippets but as direct module references. 
+By disallowing global variables, we disable this avenue of customization.
+This reduces the risk of users developing code that is
+accidentally dependent on our samples.
+
+Instead of including global variables, hard code the resource names and
+parameter values.
+
+In some cases, [local variables](#locals) are allowed.
+
+#### Local variables {#locals}
+
+Unlike global veriables, local variables are allowed in Terraform samples
+because local variables are an internal implementation and therefore aren't
+part of the API exposed via Terraform.
 
 Use local variables to reuse a common string 3 or more times that is not
 accessible as a resource reference.


### PR DESCRIPTION
Proposing Terraform for inclusion in https://googlecloudplatform.github.io/samples-style-guide/.

See:

* [go/terraform-docs-samples-repo-style](http://goto.google.com/terraform-docs-samples-repo-style)
* [go/terraform-docs-samples-repo-style_proposal](https://docs.google.com/document/d/1AL4EkD6IHQT4iNs7PcMJmuqRKp4oJMEGaUdu7N4TvjY/edit)