### PR TITLE
feat: Add specific linting guideline for PHP

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -880,6 +880,21 @@ Our code snippets should adhere to a style used by the language communities.
 We prefer to enforce style using standard linters that are popular in
 the community.
 
+{{< content-tabpane >}}
+{{< content-tab header="PHP" >}}
+
+We follow the [PSR-1][psr-1] and [PSR-2][psr-2] community coding standards, with
+one notable exception:
+
+1. The function names for sample are in `snake_case` rather than `camelCase`,
+   in order to differentiate them from class methods.
+
+[psr-1]: https://www.php-fig.org/psr/psr-1/
+[psr-2]: https://www.php-fig.org/psr/psr-2/#1-overview
+
+{{< /content-tab >}}
+{{< /content-tabpane >}}
+
 ### Portability {#portability}
 
 Each of the major operating systems are well-represented among GCP users. To

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -886,8 +886,8 @@ the community.
 We follow the [PSR-1][psr-1] and [PSR-2][psr-2] community coding standards, with
 one notable exception:
 
-1. The function names for sample are in `snake_case` rather than `camelCase`,
-   in order to differentiate them from class methods.
+* The function names for samples are in `snake_case` rather than `camelCase`,
+  in order to differentiate them from class methods.
 
 [psr-1]: https://www.php-fig.org/psr/psr-1/
 [psr-2]: https://www.php-fig.org/psr/psr-2/#1-overview


### PR DESCRIPTION
Contributes to #102 by adding specific PHP style guidance and sets up the page structure for adding additional languages later.

Continues from #99