### PR TITLE
fix: override alert shortcode for hugo rendering change

### DIFF
--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,0 +1,11 @@
+{{/* TODO: Remove when docsy fix is merged and we update. See https://github.com/google/docsy/pull/941 */}}
+{{ $color := .Get "color" | default "primary" -}}
+<div class="alert alert-{{ $color }}" role="alert">
+{{ with .Get "title" -}}
+  <div class="alert-heading">
+    {{- . | safeHTML -}}
+  </div>
+{{ end -}}
+{{/* Do **not** remove this comment! It ends above html block! See https://spec.commonmark.org/0.30/#html-blocks, 7. */}}
+{{ .Inner }}
+</div>


### PR DESCRIPTION
This change borrows a key modification from https://github.com/google/docsy/pull/941, fixing how the alert shortcode renders in versions of hugo released in the last couple years.

Once docsy ships an update with that fix, we can simply remove this override and it will fall back to wherever the theme's code lands.