### PR TITLE
styleguide: Clarify language-specific guideline todos

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1007,19 +1007,19 @@ public static void exampleSnippet(String projectId, String filePath) {
 {{% /tab %}}
 
 {{% tab header="Python" text=true %}}
-// TODO
+// There are no language-specific guidelines for Python.
 {{< /tab >}}
 
 {{% tab header="Go" text=true %}}
-// TODO
+// There are no language-specific guidelines for Go.
 {{% /tab %}}
 
 {{% tab header="Nodejs" text=true %}}
-// TODO
+// There are no language-specific guidelines for Node.js.
 {{% /tab %}}
 
 {{% tab header="C#" text=true %}}
-// TODO
+// There are no language-specific guidelines for C#.
 {{% /tab %}}
 
 {{% tab header="PHP" text=true %}}


### PR DESCRIPTION
Clarify that language-specific guidelines sections where a language has no guidelines mean there are no guidelines, not that something is unfinished. This reinforces the presence of todo in the guideline examples is part of the guideline, and not that the guideline is somehow unfinished.

Since this is addressing a formatting issue rather than a substantive guideline, I do not think it needs a formal process beyond a confirming review.